### PR TITLE
Prevent error on undefined str

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var re = /^[0-9a-fA-F]+$/;
+var re = /^[0-9a-fA-F]{24}$/;
 module.exports = function(str) {
-  if('string' !== typeof str && str.toString)
+  if(str && 'string' !== typeof str && str.toString)
     str = str.toString();
 
-  return str && str.length === 24 && re.test(str);
+  return str && re.test(str);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var objectid = require('..');
 
 describe('validate-objectid', function() {
   it('should work', function() {
+    assert(! objectid());
     assert(! objectid('test'));
     // 24 character string
     assert(! objectid('abcdefghijklmnopqrstuvwx'));


### PR DESCRIPTION
Allow an undefined str (prevent exception: Cannot read property 'toString' of undefined).
Also update regex.
Add test for undefined str.
